### PR TITLE
Report skipped/unparseable files in batch read operations

### DIFF
--- a/hugo_frontmatter_mcp.py
+++ b/hugo_frontmatter_mcp.py
@@ -264,12 +264,15 @@ def list_tags_in_directory(directory_path_str: str, recursive: bool = True) -> D
     file_pattern = "**/*.md" if recursive else "*.md"
     files_processed = 0
     files_with_tags = 0
+    errors = []
 
     for md_file_path_obj in directory_path.glob(file_pattern):
         if md_file_path_obj.is_file():
             files_processed += 1
             post, load_error = _load_post(str(md_file_path_obj))
             if load_error:
+                load_error["file_path"] = str(md_file_path_obj)
+                errors.append(load_error)
                 continue
 
             if post and isinstance(post.metadata.get("tags"), list):
@@ -286,6 +289,7 @@ def list_tags_in_directory(directory_path_str: str, recursive: bool = True) -> D
         "files_processed": files_processed,
         "files_with_tags": files_with_tags,
         "tag_counts": dict(tag_counter),
+        "errors": errors,
     }
 
 
@@ -302,12 +306,15 @@ def find_posts_by_tag(directory_path_str: str, tag_to_find: str, recursive: bool
     matching_files = []
     file_pattern = "**/*.md" if recursive else "*.md"
     files_processed = 0
+    errors = []
 
     for md_file_path_obj in directory_path.glob(file_pattern):
         if md_file_path_obj.is_file():
             files_processed += 1
             post, load_error = _load_post(str(md_file_path_obj))
             if load_error:
+                load_error["file_path"] = str(md_file_path_obj)
+                errors.append(load_error)
                 continue
 
             if post and isinstance(post.metadata.get("tags"), list):
@@ -320,6 +327,7 @@ def find_posts_by_tag(directory_path_str: str, tag_to_find: str, recursive: bool
         "recursive": recursive,
         "files_processed": files_processed,
         "matching_files": matching_files,
+        "errors": errors,
     }
 
 

--- a/tests/test_frontmatter_api.py
+++ b/tests/test_frontmatter_api.py
@@ -296,6 +296,27 @@ class TestListTagsInDirectory:
         r = list_tags_in_directory("/tmp/nonexistent_dir_abc123")
         assert "error" in r
 
+    def test_reports_malformed_files(self):
+        d = _create_md_dir(
+            [
+                ({"tags": ["python"]}, "valid post"),
+            ]
+        )
+        bad = os.path.join(d, "broken.md")
+        with open(bad, "w") as f:
+            f.write("---\ntags: [unclosed\ntitle: broken\n---\nbody\n")
+        try:
+            r = list_tags_in_directory(d)
+            # Valid file is still counted correctly.
+            assert r["tag_counts"]["python"] == 1
+            # The malformed file is reported rather than silently skipped.
+            assert len(r["errors"]) == 1
+            assert r["errors"][0]["file_path"] == bad
+        finally:
+            for f in pathlib.Path(d).glob("*.md"):
+                f.unlink()
+            os.rmdir(d)
+
 
 class TestFindPostsByTag:
     def test_finds_matching_posts(self):
@@ -323,6 +344,27 @@ class TestFindPostsByTag:
         try:
             r = find_posts_by_tag(d, "nonexistent")
             assert len(r["matching_files"]) == 0
+        finally:
+            for f in pathlib.Path(d).glob("*.md"):
+                f.unlink()
+            os.rmdir(d)
+
+    def test_reports_malformed_files(self):
+        d = _create_md_dir(
+            [
+                ({"tags": ["python"]}, "valid post"),
+            ]
+        )
+        bad = os.path.join(d, "broken.md")
+        with open(bad, "w") as f:
+            f.write("---\ntags: [unclosed\ntitle: broken\n---\nbody\n")
+        try:
+            r = find_posts_by_tag(d, "python")
+            # Valid matching file is still found.
+            assert len(r["matching_files"]) == 1
+            # The malformed file is reported rather than silently skipped.
+            assert len(r["errors"]) == 1
+            assert r["errors"][0]["file_path"] == bad
         finally:
             for f in pathlib.Path(d).glob("*.md"):
                 f.unlink()


### PR DESCRIPTION
Closes #3

## What changed
`list_tags_in_directory` and `find_posts_by_tag` previously `continue`-d past any file that failed `_load_post` (e.g. malformed YAML frontmatter), silently excluding it with no signal to the caller. Both now collect each `load_error` (tagged with its `file_path`) into an `errors` list and include that list in the returned dict.

This matches the convention already used by the sibling batch ops `rename_tag_in_directory` and `validate_date_formats`, which were the consistent ones; these two read ops were the outliers.

- All existing return keys and happy-path behavior are unchanged (valid files are still processed/counted exactly as before).
- The only addition is the new `errors` key on each function's result.

## Tests
Added a `test_reports_malformed_files` case to both `TestListTagsInDirectory` and `TestFindPostsByTag`: each drops a malformed-frontmatter `.md` file into a directory alongside a valid one, and asserts the valid file is still processed while the malformed file shows up in `errors` with its `file_path`.

## Verification
- `uv run --extra dev pytest tests/` → 34 passed
- `uv run --extra dev ruff check .` → All checks passed
- `uv run --extra dev ruff format --check .` → 2 files already formatted