### PR TITLE
Fix validation of native YAML dates

### DIFF
--- a/hugo_frontmatter_mcp.py
+++ b/hugo_frontmatter_mcp.py
@@ -8,7 +8,8 @@
 
 import pathlib
 from collections import Counter
-from datetime import datetime as dt  # Alias for datetime
+from datetime import date
+from datetime import datetime as dt
 from typing import Any, Dict, Optional, Tuple
 
 import frontmatter  # Handles reading and writing frontmatter
@@ -434,10 +435,7 @@ def validate_date_formats(
                         invalid_dates_info.append(
                             {"file_path": str(md_file_path_obj), "value": date_value, "error": str(e)}
                         )
-                elif isinstance(
-                    date_value, dt
-                ):  # If it's already a datetime object (less likely from raw frontmatter but possible)
-                    # It inherently has a valid format internally if it's a datetime object
+                elif isinstance(date_value, (dt, date)):
                     pass
                 else:
                     invalid_dates_info.append(

--- a/tests/test_frontmatter_api.py
+++ b/tests/test_frontmatter_api.py
@@ -364,6 +364,14 @@ class TestRenameTagInDirectory:
 
 
 class TestValidateDateFormats:
+    def test_native_yaml_date(self, tmp_path):
+        (tmp_path / "post.md").write_text("---\ndate: 2025-06-15\n---\n")
+
+        result = validate_date_formats(str(tmp_path))
+
+        assert result["files_with_field"] == 1
+        assert result["invalid_date_entries"] == []
+
     def test_valid_dates(self):
         d = _create_md_dir(
             [


### PR DESCRIPTION
Closes #2

## Summary
- accept `datetime.date` values parsed from unquoted YAML dates
- retain existing string format validation
- add a regression test using raw unquoted YAML frontmatter

## Verification
- `uv run --extra dev pytest tests/` — 33 passed
- `uv run --extra dev ruff check .` — passed
- `uv run --extra dev ruff format --check .` — passed