### PR TITLE
Preserve frontmatter key order on write

### DIFF
--- a/hugo_frontmatter_mcp.py
+++ b/hugo_frontmatter_mcp.py
@@ -49,7 +49,7 @@ def _save_post(file_path_str: str, post: frontmatter.Post) -> Optional[Dict[str,
     if not file_path.is_absolute():
         return {"error": f"Path for saving must be absolute: {file_path_str}", "file_path": file_path_str}
     try:
-        frontmatter.dump(post, file_path_str)
+        frontmatter.dump(post, file_path_str, sort_keys=False)
         return None
     except IOError as e:
         return {"error": f"Failed to write file: {str(e)}", "file_path": file_path_str}

--- a/tests/test_frontmatter_api.py
+++ b/tests/test_frontmatter_api.py
@@ -108,6 +108,34 @@ class TestSetTitle:
         finally:
             os.unlink(p)
 
+    def test_preserves_frontmatter_key_order(self, tmp_path: pathlib.Path):
+        post_path = tmp_path / "post.md"
+        post_path.write_text(
+            """---
+title: My Post
+date: '2024-01-15'
+draft: false
+tags: [python, hugo]
+description: Hello
+---
+Sample content.
+"""
+        )
+
+        set_title(str(post_path), "My New Post")
+
+        raw_post = post_path.read_text()
+        assert "title: My New Post" in raw_post
+        frontmatter_lines = raw_post.split("---", 2)[1].strip().splitlines()
+        top_level_keys = [line.split(":", 1)[0] for line in frontmatter_lines if ":" in line and not line[0].isspace()]
+        assert top_level_keys == [
+            "title",
+            "date",
+            "draft",
+            "tags",
+            "description",
+        ]
+
     def test_wrong_type(self):
         p = _create_md({"title": "Old"})
         try:


### PR DESCRIPTION
Closes #7

## Summary

- pass `sort_keys=False` through the single frontmatter write path
- add a regression test that starts from raw, non-alphabetical YAML, updates the title through `set_title`, and verifies the top-level key order is unchanged

## Verification

- `uv run --extra dev pytest tests/` — 36 passed
- `uv run --extra dev ruff check .` — passed
- `uv run --extra dev ruff format --check .` — passed
- Before applying the fix, `uv run --extra dev pytest tests/test_frontmatter_api.py::TestSetTitle::test_preserves_frontmatter_key_order -q` — failed because the old write path alphabetized the keys