### PR TITLE
ci: efficiency + hygiene tuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -16,7 +20,9 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
       - run: uv venv .venv
       - run: uv pip install -e ".[dev]"
       - run: uv run ruff check .
@@ -33,7 +39,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
       - run: uv venv .venv
       - run: uv pip install -e ".[dev]"
       - run: uv run pytest tests/ -v


### PR DESCRIPTION
CI efficiency + hygiene tuning (`ci.yml`):

- Add `concurrency: cancel-in-progress` to cancel superseded runs on the same ref
- Bump `astral-sh/setup-uv@v4 → @v5` and enable its cache (`enable-cache: true`) in both jobs

`push` was already scoped to `[main]`.
