### PR TITLE
Handle bare-string tags in batch read tools

### DIFF
--- a/hugo_frontmatter_mcp.py
+++ b/hugo_frontmatter_mcp.py
@@ -253,6 +253,15 @@ def remove_image(file_path: str, image_path_to_remove: str) -> Dict[str, Any]:
 # --- MCP Tools (Batch Directory Operations) ---
 
 
+def _tags_as_list(metadata: Dict[str, Any]) -> list:
+    tags = metadata.get("tags")
+    if isinstance(tags, list):
+        return tags
+    if isinstance(tags, str) and tags.strip():
+        return [tags]
+    return []
+
+
 def list_tags_in_directory(directory_path_str: str, recursive: bool = True) -> Dict[str, Any]:
     """Scans .md files in a directory for 'tags' in their frontmatter and returns tag counts. Expects an absolute directory path."""
     directory_path = pathlib.Path(directory_path_str)
@@ -276,9 +285,11 @@ def list_tags_in_directory(directory_path_str: str, recursive: bool = True) -> D
                 errors.append(load_error)
                 continue
 
-            if post and isinstance(post.metadata.get("tags"), list):
+            tags_value = post.metadata.get("tags") if post else None
+            tags = _tags_as_list(post.metadata) if post else []
+            if isinstance(tags_value, list) or tags:
                 files_with_tags += 1
-                for tag in post.metadata["tags"]:
+                for tag in tags:
                     if isinstance(tag, str):
                         tag_counter[tag] += 1
                     else:
@@ -318,9 +329,8 @@ def find_posts_by_tag(directory_path_str: str, tag_to_find: str, recursive: bool
                 errors.append(load_error)
                 continue
 
-            if post and isinstance(post.metadata.get("tags"), list):
-                if tag_to_find in post.metadata["tags"]:
-                    matching_files.append(str(md_file_path_obj))
+            if post and tag_to_find in _tags_as_list(post.metadata):
+                matching_files.append(str(md_file_path_obj))
 
     return {
         "directory_path": directory_path_str,

--- a/tests/test_frontmatter_api.py
+++ b/tests/test_frontmatter_api.py
@@ -303,11 +303,13 @@ class TestListTagsInDirectory:
                 ({"tags": ["python", "mcp"]}, "post 1"),
                 ({"tags": ["python", "ai"]}, "post 2"),
                 ({"tags": ["mcp"]}, "post 3"),
+                ({"tags": []}, "post 4"),
             ]
         )
         try:
             r = list_tags_in_directory(d)
-            assert r["files_processed"] == 3
+            assert r["files_processed"] == 4
+            assert r["files_with_tags"] == 4
             assert r["tag_counts"]["python"] == 2
             assert r["tag_counts"]["mcp"] == 2
             assert r["tag_counts"]["ai"] == 1
@@ -319,6 +321,17 @@ class TestListTagsInDirectory:
     def test_relative_path_error(self):
         r = list_tags_in_directory("relative/dir")
         assert "error" in r
+
+    def test_counts_bare_string_tag(self):
+        d = _create_md_dir([({"tags": "python"}, "post")])
+        try:
+            r = list_tags_in_directory(d)
+            assert r["files_with_tags"] == 1
+            assert r["tag_counts"] == {"python": 1}
+        finally:
+            for f in pathlib.Path(d).glob("*.md"):
+                f.unlink()
+            os.rmdir(d)
 
     def test_missing_dir_error(self):
         r = list_tags_in_directory("/tmp/nonexistent_dir_abc123")
@@ -372,6 +385,16 @@ class TestFindPostsByTag:
         try:
             r = find_posts_by_tag(d, "nonexistent")
             assert len(r["matching_files"]) == 0
+        finally:
+            for f in pathlib.Path(d).glob("*.md"):
+                f.unlink()
+            os.rmdir(d)
+
+    def test_finds_post_with_bare_string_tag(self):
+        d = _create_md_dir([({"tags": "python"}, "post")])
+        try:
+            r = find_posts_by_tag(d, "python")
+            assert r["matching_files"] == [os.path.join(d, "post0.md")]
         finally:
             for f in pathlib.Path(d).glob("*.md"):
                 f.unlink()


### PR DESCRIPTION
Closes #8

## Summary
- normalize list-valued and non-empty bare-string `tags` metadata through a shared read helper
- use the normalized tags in directory tag counts and tag searches without changing return shapes
- preserve existing list-valued behavior, including the `files_with_tags` count for an explicit empty list
- add value-based regression coverage for both affected batch tools

## Verification
- `uv run --extra dev ruff check .` — passed
- `uv run --extra dev ruff format --check .` — passed
- `uv run --extra dev pytest tests/` — 38 passed
- `git diff --check` — passed
- Mutation check: temporarily changed the bare-string normalization branch to return an empty list; both new regression tests failed on their value assertions, then the implementation was restored and the full checks passed again.
