### PR TITLE
Write the stdio server's startup message to stderr

### DIFF
--- a/hugo_frontmatter_mcp.py
+++ b/hugo_frontmatter_mcp.py
@@ -7,6 +7,7 @@
 # ///
 
 import pathlib
+import sys
 from collections import Counter
 from datetime import date
 from datetime import datetime as dt
@@ -493,7 +494,7 @@ def validate_date_formats(
 
 def main():
     """Entry point for the Hugo Frontmatter MCP server."""
-    print("Starting Hugo Frontmatter MCP server. Expects absolute paths.")
+    print("Starting Hugo Frontmatter MCP server. Expects absolute paths.", file=sys.stderr)
     mcp_server.run()
 
 

--- a/tests/test_frontmatter_api.py
+++ b/tests/test_frontmatter_api.py
@@ -4,6 +4,7 @@ import tempfile
 
 import frontmatter
 
+import hugo_frontmatter_mcp
 from hugo_frontmatter_mcp import (
     add_image,
     add_tag,
@@ -11,6 +12,7 @@ from hugo_frontmatter_mcp import (
     get_field,
     get_frontmatter,
     list_tags_in_directory,
+    main,
     remove_image,
     remove_tag,
     rename_tag_in_directory,
@@ -514,3 +516,17 @@ class TestValidateDateFormats:
     def test_relative_path_error(self):
         r = validate_date_formats("relative/dir")
         assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Entry point (stdio transport keeps stdout reserved for JSON-RPC)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_startup_message_goes_to_stderr(self, monkeypatch, capsys):
+        monkeypatch.setattr(hugo_frontmatter_mcp.mcp_server, "run", lambda: None)
+        main()
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Starting Hugo Frontmatter MCP server" in captured.err


### PR DESCRIPTION
Closes #10

Under MCP's stdio transport stdout is the JSON-RPC channel, but `main()` printed `Starting Hugo Frontmatter MCP server. Expects absolute paths.` with a bare `print(...)`, so the first bytes a client read from the server were not a protocol message.

## What changed
- `hugo_frontmatter_mcp.py`: added `import sys` and passed `file=sys.stderr` to the startup `print`. This was the only stdout write in the module (`grep -n 'print(' hugo_frontmatter_mcp.py` now shows one line, and it targets stderr).
- `tests/test_frontmatter_api.py`: added `TestMain::test_startup_message_goes_to_stderr`, which stubs `mcp_server.run`, calls the real `main()`, and asserts stdout is empty while the message appears on stderr. That keeps the fix from silently regressing, since nothing else exercises the entry point.

No tool behavior changes.

## Verification
- `uv run --extra dev ruff check .` → `All checks passed!`
- `uv run --extra dev ruff format --check .` → `2 files already formatted`
- `uv run --extra dev pytest tests/` → `39 passed`
- Mutation-tested the guard: with `file=sys.stderr` removed, the new test fails (`AssertionError: assert 'Starting Hug...lute paths.\n' == ''`); restored, it passes. So the assertion carries the behavior rather than documenting it.
- Live stdio round-trip — piped a real `initialize` request into `python hugo_frontmatter_mcp.py` with stdout and stderr captured separately. stdout now begins with `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",...` and the startup line appears only on stderr.