### PR TITLE
Keep batch tag renames from following symlinks outside the content tree

### DIFF
--- a/hugo_frontmatter_mcp.py
+++ b/hugo_frontmatter_mcp.py
@@ -383,6 +383,15 @@ def rename_tag_in_directory(
     file_pattern = "**/*.md" if recursive else "*.md"
 
     for md_file_path_obj in directory_path.glob(file_pattern):
+        if md_file_path_obj.is_symlink():
+            files_scanned += 1
+            individual_errors.append(
+                {
+                    "error": "Skipped symlink: writing through it could modify a file outside the directory.",
+                    "file_path": str(md_file_path_obj),
+                }
+            )
+            continue
         if md_file_path_obj.is_file():
             files_scanned += 1
             post, load_error = _load_post(str(md_file_path_obj))

--- a/tests/test_frontmatter_api.py
+++ b/tests/test_frontmatter_api.py
@@ -447,6 +447,25 @@ class TestRenameTagInDirectory:
                 f.unlink()
             os.rmdir(d)
 
+    def test_skips_symlinks(self, tmp_path):
+        content_dir = tmp_path / "content"
+        content_dir.mkdir()
+        outside = tmp_path / "outside.md"
+        frontmatter.dump(frontmatter.Post("outside", tags=["old"]), str(outside))
+        outside_bytes = outside.read_bytes()
+
+        frontmatter.dump(frontmatter.Post("inside", tags=["old"]), str(content_dir / "post.md"))
+        (content_dir / "linked.md").symlink_to(outside)
+
+        result = rename_tag_in_directory(str(content_dir), "old", "new")
+
+        assert result["modified_files"] == [str(content_dir / "post.md")]
+        assert outside.read_bytes() == outside_bytes
+        symlink_errors = [e for e in result["errors"] if e["file_path"] == str(content_dir / "linked.md")]
+        assert len(symlink_errors) == 1
+        assert "symlink" in symlink_errors[0]["error"].lower()
+        assert frontmatter.load(str(content_dir / "post.md")).metadata["tags"] == ["new"]
+
     def test_same_tag_noop(self):
         d = _create_md_dir([({"tags": ["a"]}, "p")])
         try:


### PR DESCRIPTION
Closes #17

`rename_tag_in_directory` accepted every glob result for which `Path.is_file()` was true. That predicate follows symlinks, so a `.md` symlink inside the requested content directory caused `_save_post` to rewrite the symlink's target — a file outside the directory the caller selected — and reported the symlink path in `modified_files` with no error.

## What changed

- `rename_tag_in_directory` now checks `is_symlink()` before `is_file()`. A symlink candidate is counted in `files_scanned`, recorded in the existing `errors` list with its path and an explanation, and skipped — it is neither loaded nor saved. Regular Markdown files in the same scan are processed as before.
- Read-only directory scans are unchanged, as the issue specifies; only the mutating batch operation narrows its write set.
- New regression test `TestRenameTagInDirectory::test_skips_symlinks` builds a content directory holding a regular post and a `.md` symlink to an external Markdown file, both tagged `old`.

## Verification

- `uv run --extra dev pytest tests/` — 40 passed (was 39).
- `uv run --extra dev ruff check .` — All checks passed. `uv run --extra dev ruff format --check .` — 2 files already formatted.
- Mutation check: with the new `is_symlink()` block removed from `hugo_frontmatter_mcp.py` (and `__pycache__` cleared), `test_skips_symlinks` fails — `modified_files` contains the `linked.md` symlink alongside the real post. Restoring the block returns the suite to 40 passed, and the diff is the intended two files.

The regression test asserts the external target is byte-for-byte unchanged (`read_bytes()` before and after), that the symlink is named in `errors`, and that the regular post's tag was still renamed and listed in `modified_files`.