### PR TITLE
Warn when set_date/set_publish_date write a non-YYYY-MM-DD value

### DIFF
--- a/hugo_frontmatter_mcp.py
+++ b/hugo_frontmatter_mcp.py
@@ -19,6 +19,8 @@ from yaml import YAMLError  # To catch parsing errors specifically
 
 mcp_server = FastMCP("HugoFrontmatterMCP")
 
+_EXPECTED_DATE_FORMAT = "%Y-%m-%d"
+
 # --- Helper Functions ---
 
 
@@ -122,16 +124,34 @@ def set_title(file_path: str, title: str) -> Dict[str, Any]:
     return _set_specific_field(file_path, "title", title, str)
 
 
+def _warn_on_unexpected_date_format(result: Dict[str, Any], value: str) -> Dict[str, Any]:
+    """Adds a non-blocking 'warning' to a successful setter result when value isn't YYYY-MM-DD.
+
+    The value is never rejected or altered — Hugo accepts date formats this check does not
+    enumerate, so this is advisory feedback only, using the same predicate as
+    validate_date_formats.
+    """
+    if "error" in result:
+        return result
+    try:
+        dt.strptime(value, _EXPECTED_DATE_FORMAT)
+    except ValueError:
+        result["warning"] = f"Value '{value}' does not match the expected date format {_EXPECTED_DATE_FORMAT}."
+    return result
+
+
 @mcp_server.tool()
 def set_date(file_path: str, date_value: str) -> Dict[str, Any]:
     """Sets the 'date' (string, e.g., YYYY-MM-DD) in the frontmatter. Expects an absolute file path."""
-    return _set_specific_field(file_path, "date", date_value, str)
+    return _warn_on_unexpected_date_format(_set_specific_field(file_path, "date", date_value, str), date_value)
 
 
 @mcp_server.tool()
 def set_publish_date(file_path: str, publish_date_value: str) -> Dict[str, Any]:
     """Sets the 'publishDate' (string, e.g., YYYY-MM-DD) in the frontmatter. Expects an absolute file path."""
-    return _set_specific_field(file_path, "publishDate", publish_date_value, str)
+    return _warn_on_unexpected_date_format(
+        _set_specific_field(file_path, "publishDate", publish_date_value, str), publish_date_value
+    )
 
 
 @mcp_server.tool()

--- a/tests/test_frontmatter_api.py
+++ b/tests/test_frontmatter_api.py
@@ -153,6 +153,34 @@ class TestSetDate:
         try:
             r = set_date(p, "2025-06-15")
             assert r["new_value"] == "2025-06-15"
+            assert "warning" not in r
+        finally:
+            os.unlink(p)
+
+    def test_warns_for_invalid_format_after_writing(self):
+        p = _create_md({"date": "2024-01-01"})
+        try:
+            r = set_date(p, "Jan 5 2024")
+            assert r["warning"] == "Value 'Jan 5 2024' does not match the expected date format %Y-%m-%d."
+            assert get_frontmatter(p)["frontmatter"]["date"] == "Jan 5 2024"
+        finally:
+            os.unlink(p)
+
+    def test_wrong_type_is_rejected_without_a_warning(self):
+        p = _create_md({"date": "2024-01-01"})
+        try:
+            r = set_date(p, 20240101)  # type: ignore[arg-type]
+            assert "error" in r
+            assert "warning" not in r
+            assert get_frontmatter(p)["frontmatter"]["date"] == "2024-01-01"
+        finally:
+            os.unlink(p)
+
+    def test_other_setters_never_warn(self):
+        p = _create_md({})
+        try:
+            assert "warning" not in set_title(p, "Jan 5 2024")
+            assert "warning" not in set_description(p, "not a date")
         finally:
             os.unlink(p)
 
@@ -163,7 +191,17 @@ class TestSetPublishDate:
         try:
             r = set_publish_date(p, "2025-07-01")
             assert r["new_value"] == "2025-07-01"
+            assert "warning" not in r
             assert get_frontmatter(p)["frontmatter"]["publishDate"] == "2025-07-01"
+        finally:
+            os.unlink(p)
+
+    def test_warns_for_invalid_format_after_writing(self):
+        p = _create_md({})
+        try:
+            r = set_publish_date(p, "20204-01-01")
+            assert r["warning"] == "Value '20204-01-01' does not match the expected date format %Y-%m-%d."
+            assert get_frontmatter(p)["frontmatter"]["publishDate"] == "20204-01-01"
         finally:
             os.unlink(p)
 


### PR DESCRIPTION
Closes #15

## What changed

`set_date` and `set_publish_date` only type-checked their argument and wrote it verbatim, so `set_date(path, "20204-01-01")` or `set_date(path, "Jan 5 2024")` succeeded silently — and only a later `validate_date_formats` run surfaced what the server itself had just written.

Successful results from these two setters now carry a non-blocking `"warning"` key when the value fails `%Y-%m-%d` parsing:

```
"warning": "Value '20204-01-01' does not match the expected date format %Y-%m-%d."
```

This is additive feedback only:

- The value is **always written, unchanged**, in both cases. No value is ever rejected, so Hugo-compatible formats this check doesn't enumerate (RFC3339 timestamps, etc.) still go through untouched.
- Scoped to the two date setters. The shared `_set_specific_field` path is unmodified, so `set_title`, `set_description`, `set_draft_status` and all list operations keep their exact existing result shape.
- A type-check failure still returns the `{"error": ...}` dict alone, with no `warning` — the helper returns early on an error result rather than warning about a value that was never written.

The check is factored into one `_warn_on_unexpected_date_format` helper rather than duplicated across both setters, matching the module's existing `_`-prefixed helper convention. It uses the same `datetime.strptime` predicate as `validate_date_formats`, so the write-time warning and the audit tool agree by construction — including agreeing that a non-zero-padded `2024-1-5` is acceptable, which `strptime` allows.

## Verification

Run from the worktree with the repo's own tooling.

**Gates — all clean:**

```
$ uv run --extra dev ruff check .
All checks passed!
$ uv run --extra dev ruff format --check .
2 files already formatted
$ uv run --extra dev pytest tests/
43 passed in 3.74s
```

**Mutation-tested, so the new tests aren't vacuous.** Each mutation was confirmed live in the interpreter (`inspect.getsource`, with `PYTHONDONTWRITEBYTECODE=1`) before trusting the red result, and the tree was confirmed clean via `git status` after each restore:

| Mutation | Result |
| --- | --- |
| Warning removed entirely (helper returns `result` unchanged) | 2 failed — `TestSetDate::test_warns_for_invalid_format_after_writing`, `TestSetPublishDate::test_warns_for_invalid_format_after_writing` |
| Warning moved into the shared `_set_specific_field` path (the plausible *wrong* fix) | 1 failed — `TestSetDate::test_other_setters_never_warn` |

Both restore runs returned to 43 passed. The two "no warning on a valid value" assertions and `test_wrong_type_is_rejected_without_a_warning` document the surrounding contract rather than carrying behaviour on their own; the three tests above are the ones that fail on a broken implementation.

**Runtime sanity:** a live stdio `initialize` handshake against `hugo_frontmatter_mcp.py` (fastmcp 3.4.5) returns the result on stdout with the banner on stderr, and the registry still lists exactly 15 tools — the new private helper is not decorated and does not leak into the MCP surface.

## Note on the alternative

Per the issue, the stricter option was to make this **blocking** (return `{"error": ...}` and skip the write on a mismatch). I kept the zero-risk warning as the default, since blocking would risk rejecting legitimate Hugo date/time formats the `%Y-%m-%d` check doesn't cover. Happy to switch if you'd prefer the strict behaviour.